### PR TITLE
Fix import of BIT fields in mysqldbimport.

### DIFF
--- a/mysql/utilities/common/table.py
+++ b/mysql/utilities/common/table.py
@@ -354,6 +354,7 @@ class Table(object):
         self.unique_not_null_indexes = None
         self.text_columns = []
         self.blob_columns = []
+        self.bit_columns = []
         self.column_format = None
         self.column_names = []
         self.column_name_type = []
@@ -433,6 +434,7 @@ class Table(object):
                     self.q_column_names.append(
                         quote_with_backticks(columns[col][0]))
                 col_type = columns[col][1].lower()
+
                 if ('char' in col_type or 'enum' in col_type
                         or 'set' in col_type or 'binary' in col_type):
                     self.text_columns.append(col)
@@ -442,6 +444,9 @@ class Table(object):
                     col_format_values[col] = "%s"
                 elif "date" in col_type or "time" in col_type:
                     col_format_values[col] = "'%s'"
+                elif "bit" in col_type:
+                    self.bit_columns.append(col)
+                    col_format_values[col] = "%d"
                 else:
                     col_format_values[col] = "%s"
         self.column_format = "%s%s%s" % \
@@ -604,6 +609,11 @@ class Table(object):
                     row_vals.append("NULL")
                 else:
                     row_vals.append(convert_special_characters(column))
+            elif index in self.bit_columns:
+                if column is None:
+                    row_vals.append("NULL")
+                else:
+                    row_vals.append(converter._BIT_to_python(column))
             else:
                 if column is None:
                     row_vals.append("NULL")
@@ -667,6 +677,10 @@ class Table(object):
                 if values[col]:
                     # Apply escape sequences to special characters
                     values[col] = convert_special_characters(values[col])
+            for col in self.bit_columns:
+                if values[col] is not None:
+                    # Convert BIT to INTEGER for dump.
+                    values[col] = MySQLConverter()._BIT_to_python(values[col])
 
             # Build string (add quotes to "string" like types)
             val_str = self.column_format % tuple(values)


### PR DESCRIPTION
NOTE: patch done as roberto.polli@oracle.com. OCA is already signed.
 
This patch dumps BIT fields using the  MySQLConverter._BIT_to_python function.

Note that in the existing code the MySQLConverter is instantiated:

  -  sometimes at the begin of the function;
  -  sometimes on the fly.

Unless it's done on purpose (eg. for some performance reasons), I suggest:

  - to use a consistent behavior;
  - to expose some of the MySQLConverter methods as public (eg. _BIT_to_python & co) as those are real functions. It could be done via sql_transform.py 