### PR TITLE
FIX automatic mysqlfailover crash with mysql 5.7

### DIFF
--- a/mysql/utilities/common/server.py
+++ b/mysql/utilities/common/server.py
@@ -1425,7 +1425,7 @@ class Server(object):
             errors.append("    GTID is not enabled.")
         if not self.check_version_compat(5, 6, 9):
             errors.append("    Server version must be 5.6.9 or greater.")
-        res = self.exec_query("SHOW VARIABLES LIKE 'gtid_executed'")
+        res = self.exec_query("SHOW GLOBAL VARIABLES LIKE 'gtid_executed'")
         if res == [] or not res[0][0] == "gtid_executed":
             errors.append("    Missing gtid_executed system variable.")
         if errors:


### PR DESCRIPTION
There is a missing “GLOBAL” keyword for mysql 5.7 (tested with 5.7.11 and 5.7.12 on the file
mysql/utilities/common/server.py.
Bug #80446
https://github.com/mysql/mysql-utilities/issues/2
SHOW GLOBAL VARIABLES stills work with mysql 5.6 (tested on 5.6.30), there is no breaking changes