### PR TITLE
mysqldiff: index filelds misordered bug fix

### DIFF
--- a/mysql/utilities/command/diff.py
+++ b/mysql/utilities/command/diff.py
@@ -62,27 +62,24 @@ def object_diff(server1_val, server2_val, object1, object2, options,
     # compare db's all objects
     include_create = options.get("include_create", False)
     # db1.*:db2.*
-    if object1.endswith('.*') and object2.endswith('.*'):
+    if include_create and object1.endswith('.*') and object2.endswith('.*'):
         direction = options.get("changes-for", None)
         reverse = options.get("reverse", False)
-        # @TODO: here assume sql_mode is the same between server1 and server2
-        sql_mode = server1.select_variable("SQL_MODE")
-        db_name1, _ = parse_object_name(object1, sql_mode)
-        db_name2, _ = parse_object_name(object2, sql_mode)
+
+        db_name1, _ = parse_object_name(object1, server1.select_variable("SQL_MODE"))
+        db_name2, _ = parse_object_name(object2, server2.select_variable("SQL_MODE"))
         in_both, in_db1, in_db2 = get_common_objects(server1, server2, 
                                                     db_name1, db_name2, True, options)
         # create/alter/drop need all objects compare
         all_object = set(in_both + in_db1 + in_db2)
-        if direction == 'server1' or direction is None or reverse:
-            print("\nUSE {0};\n".format(db_name1))
-        else:
-            print("\nUSE {0};\n".format(db_name2))
+
         # call myself recusively to compare all objects 
         for this_obj in all_object:
             object1 = db_name1 + "." + this_obj[1][0]
             object2 = db_name2 + "." + this_obj[1][0]
             # share the same connection in this loop. object_type=None
             object_diff(server1, server2, object1, object2, options, object_type=None)
+        return []
 
     # Get the object type if unknown considering that objects of different
     # types can be found with the same name.

--- a/mysql/utilities/common/database.py
+++ b/mysql/utilities/common/database.py
@@ -259,6 +259,7 @@ class Database(object):
         self.exclude_patterns = options.get("exclude_patterns", None)
         self.use_regexp = options.get("use_regexp", False)
         self.skip_table_opts = options.get("skip_table_opts", False)
+        self.skip_opt_autoinc = options.get("skip_opt_autoinc", False)
         self.new_db = None
         self.q_new_db = None
         self.init_called = False
@@ -1113,6 +1114,21 @@ class Database(object):
             # Reconstruct CREATE statement without table options.
             create_statement = "{0}{1}{2}".format(create_tbl, sep, part_opts)
 
+        elif self.skip_opt_autoinc and obj_type == _TABLE:
+            # First, get partition options.
+            create_tbl, sep, part_opts = create_statement.rpartition('\n/*')
+            # Handle situation where no partition options are found.
+            if not create_tbl:
+                create_tbl = part_opts
+                part_opts = ''
+            else:
+                part_opts = "{0}{1}".format(sep, part_opts)
+            # Then, separate table definitions from table options.
+            create_tbl, sep, _ = create_tbl.rpartition(') ')
+            tbl_opts = re.sub(r'AUTO_INCREMENT=[0-9]*', '', _)  # only remove AUTO_INCREMENT values
+            # Reconstruct CREATE statement without table options.
+            create_statement = "{0}{1}{2}{3}".format(create_tbl, sep, part_opts, tbl_opts)
+
         return create_statement
 
     def get_create_table(self, db, table):
@@ -1162,6 +1178,20 @@ class Database(object):
             create_tbl, sep, tbl_opts = create_tbl.rpartition(') ')
             # Reconstruct CREATE TABLE without table options.
             create_tbl = "{0}{1}{2}".format(create_tbl, sep, part_opts)
+        elif self.skip_opt_autoinc and obj_type == _TABLE:
+            # First, get partition options.
+            create_tbl, sep, part_opts = create_statement.rpartition('\n/*')
+            # Handle situation where no partition options are found.
+            if not create_tbl:
+                create_tbl = part_opts
+                part_opts = ''
+            else:
+                part_opts = "{0}{1}".format(sep, part_opts)
+            # Then, separate table definitions from table options.
+            create_tbl, sep, _ = create_tbl.rpartition(') ')
+            tbl_opts = re.sub(r'AUTO_INCREMENT=[0-9]*', _)  # only remove AUTO_INCREMENT values
+            # Reconstruct CREATE statement without table options.
+            create_statement = "{0}{1}{2}{3}".format(create_tbl, sep, part_opts, tbl_opts)
 
         return create_tbl, tbl_opts
 

--- a/mysql/utilities/common/dbcompare.py
+++ b/mysql/utilities/common/dbcompare.py
@@ -595,8 +595,32 @@ def diff_objects(server1, server2, object1, object2, options, object_type):
     width = options.get("width", 75)
     direction = options.get("changes-for", None)
     reverse = options.get("reverse", False)
-    skip_table_opts = options.get("skip_table_opts", False)
     compact_diff = options.get("compact", False)
+    skip_table_opts = options.get("skip_table_opts", False)
+    include_drop = options.get("include_drop", False)
+
+
+    # when object doesn't exist and include_create and db.* given, generate create sql rather than throw exception
+    if object_type.endswith("NULL"):
+        # like TABLE-NULL, db2.obj2 does not exist
+        object_type = object_type.split('-')[0]
+        object1_create = get_create_object(server1, object1, options, object_type)
+        if direction == 'server2' or reverse:
+            print(object1_create + ';\n')
+        elif include_drop:  # direction=server1 and include_drop
+            print("DROP {0} IF EXISTS {1};\n".format(object_type, object1))
+        diff_list = ["# object {0} does not exist, so create/or drop it.\n".format(object1)]
+        return diff_list
+    elif object_type.startswith("NULL"):
+        # like NULL-TABLE, db1.obj1 does not exist
+        object_type = object_type.split('-')[1]
+        object2_create = get_create_object(server2, object2, options, object_type)
+        if direction == 'server1' or direction is None or reverse:
+            print(object2_create + ';\n')
+        elif include_drop:
+            print("DROP {0} IF EXISTS {1};\n".format(object_type, object2))
+        diff_list = ["# object {0} does not exist, so create/or drop it.\n".format(object2)]
+        return diff_list
 
     # Get object CREATE statement.
     # Note: Table options are discarded if option skip_table_opts=True.

--- a/mysql/utilities/common/sql_transform.py
+++ b/mysql/utilities/common/sql_transform.py
@@ -635,7 +635,7 @@ class SQLTransformer(object):
                 def_val = to_sql(def_val)
             values['default'] = " DEFAULT %s" % def_val
         if len(col_data[_COLUMN_EXTRA]) > 0:
-            if col_data[_COLUMN_EXTRA].upper() != "AUTO_INCREMENT":
+            if col_data[_COLUMN_EXTRA].upper() == "AUTO_INCREMENT":
                 values['extra'] = " %s" % col_data[_COLUMN_EXTRA]
         if len(col_data[_COLUMN_COMMENT]) > 0:
             values['comment'] = " COMMENT '%s'" % col_data[_COLUMN_COMMENT]

--- a/mysql/utilities/common/sql_transform.py
+++ b/mysql/utilities/common/sql_transform.py
@@ -364,6 +364,7 @@ class SQLTransformer(object):
         if options is None:
             options = {}
         self.skip_table_opts = options.get("skip_table_opts", False)
+        self.skip_opt_autoinc = options.get("skip_opt_autoinc", False)
 
     def transform_definition(self):
         """Transform an object definition
@@ -590,6 +591,10 @@ class SQLTransformer(object):
         # Check for rename
         if destination[_TABLE_NAME] != source[_TABLE_NAME]:
             statement_parts[0]['val'] = (source[_DB_NAME], source[_TABLE_NAME])
+
+        # Check skip_opt_autoinc (discard auto_increment or not)
+        if self.skip_opt_autoinc:
+            statement_parts[2]['val'] = ''
 
         # check and set commas
         do_comma = False
@@ -1179,7 +1184,7 @@ class SQLTransformer(object):
         else:
             gen_defn = None
 
-        if gen_defn is not None:
+        if gen_defn:
             statements.append(gen_defn)
 
         # Form the SQL command.

--- a/mysql/utilities/common/sql_transform.py
+++ b/mysql/utilities/common/sql_transform.py
@@ -919,6 +919,7 @@ class SQLTransformer(object):
         TABLE commands for defining the indexes for the table.
 
         rows[in]           result set of index definitions
+                           rows must have ordered by index seq_no
 
         Returns list - list of SQL index clause statements or
                        [] if no indexes
@@ -997,6 +998,7 @@ class SQLTransformer(object):
         """
         from mysql.utilities.common.table import Table
         from mysql.utilities.common.dbcompare import get_common_lists
+        from collections import defaultdict
 
         # Get the Table instances
         self.dest_tbl = Table(self.destination_db.source, "%s.%s" %
@@ -1014,8 +1016,32 @@ class SQLTransformer(object):
         src_idx = [('',) + tuple(idx[1:])
                    for idx in self.src_tbl.get_tbl_indexes()]
 
+        # get add or drop index by comparing idx_name, not index field columns
+        dest_idx_dict = defaultdict(list)
+        src_idx_dict = defaultdict(list)
+        for idx_f in dest_idx:  # idx_f: index fields
+            dest_idx_dict[idx_f[2]].append(idx_f)
+        for idx_f in src_idx:
+            src_idx_dict[idx_f[2]].append(idx_f)
+
+        same_idx_name, drop_idx_name, add_idx_name = get_common_lists(dest_idx_dict.keys(), src_idx_dict.keys())
+
         # Now we determine the indexes we need to add and those to drop
-        _, drop_idx, add_idx = get_common_lists(dest_idx, src_idx)
+        # two table have the same index_name but different fields, drop and add new one.
+        if len(same_idx_name) > 0:
+            for idx_name in same_idx_name:
+                if dest_idx_dict[idx_name] != src_idx_dict[idx_name]:
+                    drop_idx_name.append(idx_name)
+                    add_idx_name.append(idx_name)
+
+        add_idx = []
+        drop_idx = []
+        for d in add_idx_name:
+            add_idx.extend(src_idx_dict[d])
+
+        for d in drop_idx_name:
+            drop_idx.extend(dest_idx_dict[d])
+
         if not drop_idx and not add_idx:
             return ([], [])
 

--- a/scripts/mysqldiff.py
+++ b/scripts/mysqldiff.py
@@ -200,6 +200,17 @@ if __name__ == '__main__':
                       dest="skip_opt_autoinc",
                       help="skip table option AUTO_INCREMENT only")
 
+    # create table/view/proc/func/event/trig if not exists. (skip database/grants )
+    parser.add_option("--include-create", action="store_true",
+                      dest="include_create",
+                      help="create objects(like TABLE.) if not exists in target db(changes-for) "
+                           "only work in when difftype is sql .")
+
+    # drop table/view/proc/func/event/trig if they ONLY exist in source db
+    parser.add_option("--include-drop", action="store_true", default=False,
+                      dest="include_drop",
+                      help="drop objects(like TABLE.) if only exists in source db "
+                           "only work in when difftype is sql .")
 
     # Add verbosity and quiet (silent) mode
     add_verbosity(parser, True)
@@ -233,12 +244,18 @@ if __name__ == '__main__':
         "reverse": opt.reverse,
         "skip_table_opts": opt.skip_tbl_opts,
         "skip_opt_autoinc": opt.skip_opt_autoinc,
+        "include_create": opt.include_create,
+        "include_drop": opt.include_drop,
         "compact": opt.compact,
         "charset": opt.charset,
     }
 
     # add ssl options values.
     options.update(get_ssl_dict(opt))
+
+    # check include_create/drop only for difftype=sql
+    if (opt.include_create or opt.include_drop) and opt.difftype != 'sql':
+        parser.error("--include-create or --include-drop only is allowed only when --difftype=sql ")
 
     # Parse server connection values
     try:

--- a/scripts/mysqldiff.py
+++ b/scripts/mysqldiff.py
@@ -196,6 +196,11 @@ if __name__ == '__main__':
                       help="skip check of all table options (e.g., "
                            "AUTO_INCREMENT, ENGINE, CHARSET, etc.).")
 
+    parser.add_option("--skip-opt-autoinc", action="store_true", default=False,
+                      dest="skip_opt_autoinc",
+                      help="skip table option AUTO_INCREMENT only")
+
+
     # Add verbosity and quiet (silent) mode
     add_verbosity(parser, True)
 
@@ -227,6 +232,7 @@ if __name__ == '__main__':
         "changes-for": opt.changes_for,
         "reverse": opt.reverse,
         "skip_table_opts": opt.skip_tbl_opts,
+        "skip_opt_autoinc": opt.skip_opt_autoinc,
         "compact": opt.compact,
         "charset": opt.charset,
     }


### PR DESCRIPTION
1. in sql_transform.py:_get_index_sql_clauses(), rows parameter must be ordered by index seq_no, since index filelds have order. But when using get_common_lists() to get add/drop index, index fileds are disordered (set() operation)
This leads to the wrong index clauses: idx1(f1,f2) is constructed to idx1(f2,f1) probably.

2. using get_common_lists() to get add/drop index, will missing some index filelds:
table1: idx1(f1,f2)
table2: idx1(f1)
idx1(f2) will be constructed, that's too bad.