### PR TITLE
Add tables to be specified in dbcompare

### DIFF
--- a/mysql/utilities/command/dbcompare.py
+++ b/mysql/utilities/command/dbcompare.py
@@ -415,6 +415,9 @@ def database_compare(server1_val, server2_val, db1, db2, options):
 
     _check_option_defaults(options)
     quiet = options.get("quiet", False)
+    include_tables = options.get("include_tables")
+    if include_tables:
+        include_tables = include_tables.split(",")
 
     # Connect to servers
     server1, server2 = server_connect(server1_val, server2_val,
@@ -460,6 +463,10 @@ def database_compare(server1_val, server2_val, db1, db2, options):
         debug_msgs = []
         # Set the object type
         obj_type = item[0]
+        table_name = item[1][0]
+
+        if include_tables and table_name not in include_tables:
+            continue
 
         q_obj1 = "{0}.{1}".format(quote_with_backticks(db1, server1_sql_mode),
                                   quote_with_backticks(item[1][0],

--- a/scripts/mysqldbcompare.py
+++ b/scripts/mysqldbcompare.py
@@ -172,6 +172,10 @@ if __name__ == '__main__':
              "primary key (each of his columns must not allow null values)."
     )
 
+    parser.add_option("--include-tables", action="store", dest="include_tables",
+                      type="string", default=None,
+                      help="tables to include")
+
     # Add verbosity and quiet (silent) mode
     add_verbosity(parser, True)
 
@@ -255,6 +259,7 @@ if __name__ == '__main__':
         "all": opt.all,
         "use_regexp": opt.use_regexp,
         "exclude_patterns": exclude_list,
+        "include_tables": opt.include_tables,
     }
 
     # Add ssl options to options instead of connection.


### PR DESCRIPTION
Sometime we do not wish to compare all the tables in a database. This changes adds the option to specify which table (or tables) we need to compare.

This can be achieved by supplying the argument `--include-tables=core_user,core_item` with CSV of the tables you wish to compare.
