### PR TITLE
Properly quote the definer for CREATE / ALTER VIEW statements.

### DIFF
--- a/mysql/utilities/common/sql_transform.py
+++ b/mysql/utilities/common/sql_transform.py
@@ -1224,6 +1224,10 @@ class SQLTransformer(object):
         if self._check_columns([_VIEW_DEFINER, _VIEW_SECURITY, _VIEW_CHECK]):
             statement_parts[4]['val'] = self.source[_VIEW_BODY]
 
+        # properly quote the definer
+        statement_parts[1] = {'fmt': " DEFINER=%s", 'col': _IGNORE_COLUMN,
+                              'val': "`%s`@`%s`" % tuple(self.source[_VIEW_DEFINER].split("@"))}
+
         # form the drop if we do a create
         if do_create:
             statements.append("DROP VIEW IF EXISTS `%s`.`%s`;" %


### PR DESCRIPTION
The definer taken directly from INFORMATION_SCHEMA.VIEWS.DEFINER  can not be used in SQL statements, because it is not properly quoted. The outputted SQL statement can not be executed and leads to a SQL error.

This commit properly quotes the definer so that the outputted SQL statement can be executed.
I am not a Python programmer and I am new to mysql-utilities, so there might be a better, shorter or more elegant way to write this fix, but as far as I can tell, the fix gets its job done pretty well.