### PR TITLE
ISSUE-36: Avoid using SHOW DATABASES for alive check

### DIFF
--- a/mysql/utilities/common/server.py
+++ b/mysql/utilities/common/server.py
@@ -846,7 +846,7 @@ class Server(object):
                 # to make sure connection is really alive
                 retval = self.db_conn.is_connected()
                 if retval:
-                    self.exec_query("SHOW DATABASES")
+                    self.exec_query("SELECT 1 FROM DUAL")
                 else:
                     res = False
         except:


### PR DESCRIPTION
MySQL 8.0 somehow starts a transaction when SHOW DATABASES is called.
Inadvertantly starting a transaction prevents disabling LOG_BIN
using SET SQL_LOG_BIN=0. Change the Server.is_alive() function
to use SELECT 1 FROM DUAL instead.

Fixes: https://github.com/mysql/mysql-utilities/issues/36