### PR TITLE
Use rsplit instead of split to get mysql session user and host

### DIFF
--- a/mysql/utilities/common/parser.py
+++ b/mysql/utilities/common/parser.py
@@ -361,7 +361,7 @@ class GeneralQueryLog(LogParserBase):
         except ValueError:
             connection = argument.replace(' on', '')
             database = None
-        session['user'], session['host'] = connection.split('@')
+        session['user'], session['host'] = connection.rsplit('@', 1)
         session['database'] = database
         entry['argument'] = argument
 


### PR DESCRIPTION
Using split fails if the user name contains `@`, so use rsplit instead and consider the last bit as host name.